### PR TITLE
Remove hello@goharbor.io

### DIFF
--- a/themes/harbor/layouts/partials/single/template-community.html
+++ b/themes/harbor/layouts/partials/single/template-community.html
@@ -80,7 +80,7 @@
 <section class="module module--content">
     <div class="container wrap">
         <p class="pad-t-3">
-            Below are some of Harbor’s users and partners. If you would like to be listed on this page as a reference user or partner, please contact us at <a href="mailto:harbor@vmware.com" class="hlink">hello@goharbor.io</a>.
+            Below are some of Harbor’s users and partners. If you would like to be listed on this page as a reference user or partner, please send an email to <a href="mailto:harbor-users@lists.cncf.io" class="hlink">harbor-users@lists.cncf.io</a>, or reach out to us on [Slack](https://cncf.slack.com/messages/harbor).
         </p>
     </div>
 </section>


### PR DESCRIPTION
Replace hello@goharbor.io with a link to send an email to the user distribution list, or reach out to us on Slack.

Signed-off-by: jonasrosland <jrosland@vmware.com>