### PR TITLE
Fix links to #harbor on cloud-native.slack.com

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -90,7 +90,7 @@ params:
       handle: "@project_harbor"
     - title: Slack
       logo: /img/icons/slack-icon.svg
-      link: https://cncf.slack.com/messages/harbor
+      link: https://cloud-native.slack.com/messages/harbor
       handle: "#harbor"
     - title: User Group
       logo: /img/icons/user-group-icon.svg
@@ -201,7 +201,7 @@ params:
         url: "https://twitter.com/project_harbor"
         icon: /img/icons/twitter-icon.svg
       - name: Slack
-        url: "https://cncf.slack.com/messages/harbor"
+        url: "https://cloud-native.slack.com/messages/harbor"
         icon: /img/icons/slack-icon.svg
       - name: User Group
         url: "https://groups.google.com/forum/#!forum/harbor-users"

--- a/content/blogs/harbor-1.7.0-release.md
+++ b/content/blogs/harbor-1.7.0-release.md
@@ -58,6 +58,6 @@ who've spent time working on Harbor and contributing to the project:
 ## Join the Fun
 Many thanks to the community for your continued support! We love contributions
 of any kind, including tweaking the documentation, helping others in our
-#harbor [Slack channel](https://cncf.slack.io/), adding docs, tests or even
+#harbor [Slack channel](https://slack.cncf.io/), adding docs, tests or even
 performing code reviews. You can find details on joining us
 [here](https://goharbor.io/community/).

--- a/themes/harbor/layouts/partials/single/template-community.html
+++ b/themes/harbor/layouts/partials/single/template-community.html
@@ -28,7 +28,7 @@
                         <div class="list-article-info">
                             <p>Join Harbor's community to discuss your experience and ask questions:
                             <br/>
-                                <a href="https://slack.cncf.io" class="hlink">CNCF Slack;</a>, channel: <a href="https://cncf.slack.com/messages/harbor">#harbor</a>.
+                                <a href="https://slack.cncf.io" class="hlink">CNCF Slack;</a>, channel: <a href="https://cloud-native.slack.com/messages/harbor">#harbor</a>.
                             </p>
 
                         </div>
@@ -80,7 +80,7 @@
 <section class="module module--content">
     <div class="container wrap">
         <p class="pad-t-3">
-            Below are some of Harbor’s users and partners. If you would like to be listed on this page as a reference user or partner, please send an email to <a href="mailto:harbor-users@lists.cncf.io" class="hlink">harbor-users@lists.cncf.io</a>, or reach out to us on [Slack](https://cncf.slack.com/messages/harbor).
+            Below are some of Harbor’s users and partners. If you would like to be listed on this page as a reference user or partner, please send an email to <a href="mailto:harbor-users@lists.cncf.io" class="hlink">harbor-users@lists.cncf.io</a>, or reach out to us on [Slack](https://cloud-native.slack.com/messages/harbor).
         </p>
     </div>
 </section>


### PR DESCRIPTION
I tried to join on slack, only to find that I was trying to join a different cncf... these are not the links for the cncf that you think they are :p 

cncf.slack.com is for the community of the Canadian National Christian Foundation
cncf.slack.io is not registered: ```$ host cncf.slack.io
Host cncf.slack.io not found: 3(NXDOMAIN)```

