### PR TITLE
fix distribution list links

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -201,10 +201,10 @@ params:
         url: "https://cloud-native.slack.com/messages/harbor"
         icon: /img/icons/slack-icon.svg
       - name: User Group
-        url: "https://groups.google.com/forum/#!forum/harbor-users"
+        url: "https://lists.cncf.io/g/harbor-users"
         icon: /img/icons/user-group-icon.svg
       - name: Developer Group
-        url: "https://groups.google.com/forum/#!forum/harbor-dev"
+        url: "https://lists.cncf.io/g/harbor-dev"
         icon: /img/icons/dev-group-icon.svg
     followUs:
     - icon: github

--- a/content/blogs/contributing.md
+++ b/content/blogs/contributing.md
@@ -151,7 +151,8 @@ appropriate. We make mistakes, too.
 I'll follow-up with future blog posts with further discussion on how to
 contribute to Harbor. Contributing code can be more involved, particularly if
 the feature is large, but we encourage you to join the fun.  You can find us
-on GitHub, Slack or on the harbor-users and harbor-dev Google Groups mailing
-list.
+on [GitHub](https://github.com/goharbor), [Slack](https://cloud-native.slack.com/messages/harbor),
+or on the [harbor-users](https://lists.cncf.io/g/harbor-users) and [harbor-dev](https://lists.cncf.io/g/harbor-dev)
+mailing lists.
 
 Thanks for reading!


### PR DESCRIPTION
This will fix the footer's links to the distribution lists, and also include proper links in the "Contributing 101" blog.

Signed-off-by: jonasrosland <jrosland@vmware.com>