### PR TITLE
Improve modal image click away

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,10 +1,12 @@
 {{ $src := .Destination | safeURL }}
 {{ $id  := index (last 1 (split .Destination "/")) 0 | replaceRE ".png" "" }}
-<figure x-data="{ open: false }">
-  <img class="img" src="{{ $src }}"{{ with .Text }} alt="{{ . }}"{{ end }} id="{{ $id }}" @click="open = true">
+<div x-data="{ open: false }">
+  <figure>
+    <img class="img" src="{{ $src }}"{{ with .Text }} alt="{{ . }}"{{ end }} id="{{ $id }}" @click="open = true">
+  </figure>
 
   <div class="modal" id="modal-{{ $id }}" :class="{ 'is-active': open }">
-    <div class="modal-background"></div>
+    <div class="modal-background" @click="open = false"></div>
     <div class="modal-content">
       <p class="image">
         <img src="{{ $src }}"{{ with .Text }} alt="{{ . }}"{{ end }}>
@@ -13,4 +15,4 @@
   
     <button class="modal-close is-large" aria-label="close" @click="open = false"></button>
   </div>
-</figure>
+</div>


### PR DESCRIPTION
Currently, getting out of an image display modal requires clicking the small "x" icon in the upper right. This PR will enable people to get out of the modal by clicking anywhere outside of the image.