### PR TITLE
Fix docs main width and sticky footer

### DIFF
--- a/assets/sass/helpers.sass
+++ b/assets/sass/helpers.sass
@@ -66,3 +66,11 @@ hr.color
   .img
     &:hover
       cursor: pointer
+
+.is-page
+  display: flex
+  flex-direction: column
+  min-height: 100vh
+
+  .is-main
+    flex: 1

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,11 +16,13 @@
     <script async defer src="https://buttons.github.io/buttons.js"></script>
     {{ end }}
   </head>
-  <body class="has-navbar-fixed-top">
-    {{ partial "navbar.html" . }}
+  <body class="is-page has-navbar-fixed-top">
+    <main class="is-main">
+      {{ partial "navbar.html" . }}
 
-    {{ block "main" . }}
-    {{ end }}
+      {{ block "main" . }}
+      {{ end }}
+    </main>
 
     {{ partial "footer.html" . }}
     {{ partial "javascript.html" }}

--- a/layouts/partials/docs/layout.html
+++ b/layouts/partials/docs/layout.html
@@ -7,7 +7,7 @@
         </aside>
       </div>
 
-      <div class="column">
+      <div class="column is-half">
         <div class="content is-constrained has-extra-bottom-padding is-medium">
           {{ with .Content }}
           {{ . }}
@@ -18,7 +18,7 @@
           {{ if .Content }}
           <hr class="thick" />
           {{ end }}
-          
+
           {{ with .Sections }}
           <h2 id="subsections">
             Subsections

--- a/layouts/partials/docs/sidebar.html
+++ b/layouts/partials/docs/sidebar.html
@@ -16,7 +16,7 @@
 
     <br /><br />
     {{ end }}
-    
+
     <p class="title is-size-4">
       <span class="icon has-margin-right has-text-grey-light">
         <i class="fas fa-folder-plus"></i>


### PR DESCRIPTION
This PR fixes two rendering issues. On different docs pages the width of the main content section (the middle section) varies because the Bulma column doesn't have a specified width. This PR specifies a width and eliminates the issue.

Another issue is that pages like https://goharbor.io/docs/1.10/working-with-projects don't have a "sticky" footer because the page content isn't pushing the footer down to the bottom. This PR addresses that as well.