### PR TITLE
Make load-docs.sh use local branches

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,7 +28,7 @@ branchname = "release-2.0.0"
 [[params.versions]]
 harborversion = "1.10"
 helmversion = "1.3"
-branchname = "release-1.10-doc"
+branchname = "release-1.10"
 
 [params.info]
 what_is = "Harbor is an open source container image registry that secures images with role-based access control, scans images for vulnerabilities, and signs images as trusted. As a CNCF Incubating project, Harbor delivers compliance, performance, and interoperability to help you consistently and securely manage images across cloud native compute platforms like Kubernetes and Docker."

--- a/load-docs.sh
+++ b/load-docs.sh
@@ -18,9 +18,9 @@ GIT_VERSION=$(git --version)
 # Look at the git tags and generate a list of releases
 # that we want to show docs for.
 if [[ -z ${OFFLINE} ]]; then
-    git fetch ${REPOSITORY_URL:-https://github.com/goharbor/harbor.git}
+    git fetch ${REPOSITORY_URL:-https://github.com/goharbor/website.git}
 fi
-ALL_RELEASES=$(git ls-remote https://github.com/goharbor/harbor | grep release | awk -F/ '{print $3}' | sort -r -V)
+ALL_RELEASES=$(git ls-remote https://github.com/goharbor/website | grep release | awk -F/ '{print $3}' | sort -r -V)
 RELEASES=()
 PREV_MAJOR_VER="-1"
 PREV_MINOR_VER="-1"
@@ -114,10 +114,10 @@ for release in "${RELEASES[@]}"; do
     # Don't error if the checkout fails
     set +e
     if [[ ${release} != "master" ]]; then
-        git fetch https://github.com/goharbor/harbor.git ${release}:${release}
-        git checkout ${release}
+        git fetch https://github.com/goharbor/website.git ${release}:${release}-local
+        git checkout ${release}-local
     else
-        git fetch https://github.com/goharbor/harbor.git ${release}:master-dev
+        git fetch https://github.com/goharbor/website.git ${release}:master-dev
         git checkout master-dev
     fi
     errc=$?


### PR DESCRIPTION
This will change the behavior of load-docs.sh to use the local branches in /website instead of the docs branches in /harbor

Signed-off-by: jonasrosland <jrosland@vmware.com>