### PR TITLE
Updating Quay capabilities

### DIFF
--- a/docs/build-customize-contribute/registry-landscape.md
+++ b/docs/build-customize-contribute/registry-landscape.md
@@ -19,7 +19,7 @@ Table updated on 10/21/2019 against Harbor 1.9.
 | LDAP-based Auth                                        | ✓      | ✓                       | ✓       | partial                           | ✗                           | ✓           | ✓        |
 | Local Auth                                             | ✓      | ✓                       | ✓       | ✓                                 | ✗                           | ✓           | ✓        |
 | Multi-Tenancy (projects, teams, namespaces, etc)       | ✓      | ✓                       | ✓       | partial                           | ✗                           | ✓           | ✓        |
-| Open Source                                            | ✓      | partial                 | ✗       | ✗                                 | ✓                           | partial     | partial  |
+| Open Source                                            | ✓      | partial                 | ✓       | ✗                                 | ✓                           | partial     | partial  |
 | Project Quotas (by image count & storage consumption)  | ✓      | ✗                       | ✗       | partial                           | ✗                           | ✗           | ✗        |
 | Replication between instances                          | ✓      | ✓                       | ✓       | n/a                               | ✗                           | ✓           | ✗        |
 | Replication between non-instances                      | ✓      | ✗                       | ✓       | n/a                               | ✗                           | ✗           | ✗        |
@@ -27,9 +27,9 @@ Table updated on 10/21/2019 against Harbor 1.9.
 | Robot Accounts for Images                              | ✓      | ?                       | ✓       | ?                                 | ✗                           | ?           | ?        |
 | Role-Based Access Control                              | ✓      | ✓                       | ✓       | ✓                                 | ✗                           | ✓           | ✗        |
 | Single Sign On (OIDC)                                  | ✓      | ✓                       | ✓       | ✓                                 | ✗                           | partial     | ✗        |
-| Tag Retention Policy                                   | ✓      | ✗                       | partial | ✗                                 | ✗                           | ✗           | ✗        |
+| Tag Retention Policy                                   | ✓      | ✗                       | ✓       | ✗                                 | ✗                           | ✗           | ✗        |
 | Upstream Registry Proxy Cache                          | ✗      | ✓                       | ✗       | ✗                                 | ✓                           | ✓           | ✗        |
 | Vulnerability Scanning & Monitoring                    | ✓      | ✓                       | ✓       | ✗                                 | ✗                           | ✓           | partial  |
-| Vulnerability Scanning Plugin Framework                | ✓      | ✗                       | ✗       | ✗                                 | ✗                           | ✗           | ✗        |
+| Vulnerability Scanning Plugin Framework                | ✓      | ✗                       | ✓       | ✗                                 | ✗                           | ✗           | ✗        |
 | Vulnerability Allowlisting                             | ✓      | ✗                       | ✗       | ✗                                 | ✗                           | ✗           | ✗        |
 | Webhooks                                               | ✓      | ✓                       | ✓       | ✓                                 | ✓                           | ✓           | ✓        |


### PR DESCRIPTION
[Quay](https://projectquay.io) is an Open Source project, that is currently submitted as CNCF sandbox. It actually does feature Tag Retention policies (I am unsure what partial refers to) and with Clair v4 it also has the ability to plug additional scanners into the vulnerability framework.