### PR TITLE
[release-2.1.0] Fix proxy cache example to include pulling from single level repositories. (9228db27)

### DIFF
--- a/docs/administration/configure-proxy-cache/_index.md
+++ b/docs/administration/configure-proxy-cache/_index.md
@@ -55,7 +55,9 @@ To start using the proxy cache, configure your docker pull commands or pod manif
 
 ```bash
 > docker pull <harbor_server_name>/<proxy_project_name>/goharbor/harbor-core:dev
+```
+To pull official images or from single level repositories, make sure to include the 'library' namespace.
 
-# To pull offcial images, use the 'library' namespace
-> docker pull <harbor_server_name>/<proxy_project_name>/library/hello-world:latest
+```bash
+> docker pull <harbor_server_name>/library/hello-world:latest
 ```


### PR DESCRIPTION
Backports the following commits to release-2.1.0:
 - Fix proxy cache example to include pulling from single level repositories. (9228db27)