### PR TITLE
fix: update location of swagger.yaml file

### DIFF
--- a/docs/build-customize-contribute/configure-swagger.md
+++ b/docs/build-customize-contribute/configure-swagger.md
@@ -6,7 +6,7 @@ A Swagger file is provided for viewing and testing Harbor REST API.
 
 ## Viewing Harbor REST API
 
-* Open the file **swagger.yaml** under the _docs_ directory in Harbor project
+* Open the file **swagger.yaml** under the _api_ directory in Harbor project
 * Paste all its content into the online Swagger Editor at http://editor.swagger.io. The descriptions of Harbor API will be shown on the right pane of the page.
 
 ![Swagger Editor](../../img/swagger-editor.png)

--- a/docs/build-customize-contribute/configure-swagger.md
+++ b/docs/build-customize-contribute/configure-swagger.md
@@ -6,7 +6,7 @@ A Swagger file is provided for viewing and testing Harbor REST API.
 
 ## Viewing Harbor REST API
 
-* Open the file **swagger.yaml** under the _api_ directory in Harbor project
+* Open the file **swagger.yaml** under the _api/v2.0_ directory in Harbor project
 * Paste all its content into the online Swagger Editor at http://editor.swagger.io. The descriptions of Harbor API will be shown on the right pane of the page.
 
 ![Swagger Editor](../../img/swagger-editor.png)


### PR DESCRIPTION
it looks like the `swagger.yaml` file actually lives in the `api` directory, not the `docs` directory: https://github.com/goharbor/harbor/blob/master/api/swagger.yaml