### PR TITLE
fix invalid proxy cache single level pull example

### DIFF
--- a/docs/administration/configure-proxy-cache/_index.md
+++ b/docs/administration/configure-proxy-cache/_index.md
@@ -66,5 +66,5 @@ To start using the proxy cache, configure your docker pull commands or pod manif
 To pull official images or from single level repositories, make sure to include the 'library' namespace.
 
 ```bash
-> docker pull <harbor_server_name>/library/hello-world:latest
+> docker pull <harbor_server_name>/<proxy_project_name>/library/hello-world:latest
 ```


### PR DESCRIPTION
It seems that a commit (9228db27) last year made the proxy cache documentation inaccurate. I recently setup a proxy cache solution with Harbor and found the docs confusing. So the commit in this PR fixes the example.

Evidence of the correct usage:
```
 ~ ❯❯❯ docker pull <omitted domain>/proxy-cache/library/nginx
Using default tag: latest
latest: Pulling from proxy-cache/library/nginx
Digest: sha256:d2925188effb4ddca9f14f162d6fba9b5fab232028aa07ae5c1dab764dca8f9f
Status: Image is up to date for <omitted domain>/proxy-cache/library/nginx:latest
<omitted domain>/proxy-cache/library/nginx:latest
```
vs the way the docs currently indicate:
```
 ~ ❯❯❯ docker pull <omitted domain>/library/nginx
Using default tag: latest
Error response from daemon: unknown: repository library/nginx not found
```