### PR TITLE
fixed metric enable key

### DIFF
--- a/docs/install-config/configure-yml-file.md
+++ b/docs/install-config/configure-yml-file.md
@@ -329,7 +329,7 @@ The following table lists the additional, optional parameters that you can set t
   </tr>
   <tr>
     <td valign="top">&nbsp;</td>
-    <td valign="top"><code>enable</code></td>
+    <td valign="top"><code>enabled</code></td>
     <td valign="top">Enable exposing metrics on your Harbor instance by setting this to <code>true</code>. Default is <code>false</code></td>
   </tr>
   <tr>


### PR DESCRIPTION
This PR fix the documenation about the metric configuration.
When `enable`is used i got the following error:
```
Traceback (most recent call last):
  File "main.py", line 15, in <module>
    cli()
  File "/usr/lib/python3.6/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/src/app/commands/prepare.py", line 37, in prepare
    config_dict = parse_yaml_config(conf, with_notary=with_notary, with_trivy=with_trivy, with_chartmuseum=with_chartmuseum)
  File "/usr/src/app/utils/configs.py", line 326, in parse_yaml_config
    config_dict['metric'] = Metric(metric_config['enabled'], metric_config['port'], metric_config['path'])
KeyError: 'enabled'
```

instead the key `enabled`must be set to `true` to enable the metric endpoint