### PR TITLE
Update use of GOBUILDIMAGE variable on build

### DIFF
--- a/docs/build-customize-contribute/compile-guide.md
+++ b/docs/build-customize-contribute/compile-guide.md
@@ -15,7 +15,7 @@ Harbor is deployed as several Docker containers and most of the code is written 
 | python         | 2.7 +            |
 | git            | 1.9.1 +          |
 | make           | 3.81 +           |
-| golang\*       | 1.13.8 +          |
+| golang\*       | 1.15.6 +         |
 
 \*optional, required only if you use your own Golang environment.
 
@@ -42,22 +42,16 @@ You can compile the code by one of the two approaches:
 
 #### I. Build with official Golang image
 
-- Get official Golang image from docker hub:
-
-    ```sh
-    docker pull golang:1.13.8
-    ```
-
 - Build, install and bring up Harbor without Notary:
 
     ```sh
-    make install GOBUILDIMAGE=golang:1.13.8 COMPILETAG=compile_golangimage
+    make install COMPILETAG=compile_golangimage
     ```
 
 - Build, install and bring up Harbor with Notary:
 
     ```sh
-    make install GOBUILDIMAGE=golang:1.13.8 COMPILETAG=compile_golangimage NOTARYFLAG=true
+    make install COMPILETAG=compile_golangimage NOTARYFLAG=true
     ```
 
 #### II. Compile code with your own Golang environment, then build Harbor

--- a/docs/build-customize-contribute/use-make.md
+++ b/docs/build-customize-contribute/use-make.md
@@ -44,13 +44,13 @@ version				 | set harbor version
 ### Build and run harbor from source code
 
 ```sh
-make install GOBUILDIMAGE=golang:1.14.5 COMPILETAG=compile_golangimage NOTARYFLAG=true
+make install GOBUILDIMAGE=golang:1.15.6 COMPILETAG=compile_golangimage NOTARYFLAG=true
 ```
 
 ### Package offline installer
 
 ```sh
-make package_offline GOBUILDIMAGE=golang:1.14.5 COMPILETAG=compile_golangimage NOTARYFLAG=true
+make package_offline GOBUILDIMAGE=golang:1.15.6 COMPILETAG=compile_golangimage NOTARYFLAG=true
 ```
 
 ### Start harbor with notary


### PR DESCRIPTION
Updates use of `GOBUILDIMAGE` variable and follows the Go version updated in the main repo (i.e., goharbor/harbor#13836) on build.

As https://goharbor.io/docs/2.2.0/build-customize-contribute/use-make/ describes the variable including `GOBUILDIMAGE` and examples with it, it does not look like https://goharbor.io/docs/2.2.0/build-customize-contribute/compile-guide/ requires newbies to specify `GOBUILDIMAGE` variable.

