### PR TITLE
correct single level pull command

### DIFF
--- a/docs/administration/configure-proxy-cache/_index.md
+++ b/docs/administration/configure-proxy-cache/_index.md
@@ -59,5 +59,5 @@ To start using the proxy cache, configure your docker pull commands or pod manif
 To pull official images or from single level repositories, make sure to include the 'library' namespace.
 
 ```bash
-> docker pull <harbor_server_name>/library/hello-world:latest
+> docker pull <harbor_server_name>/<proxy_project_name>/library/hello-world:latest
 ```


### PR DESCRIPTION
The example command for pulling a single level or official image was missing the proxy project name before /library/.