### PR TITLE
Add upgrade to 2.5 docs

### DIFF
--- a/docs/administration/upgrade/_index.md
+++ b/docs/administration/upgrade/_index.md
@@ -3,7 +3,13 @@ title: Upgrade Harbor and Migrate Data
 weight: 45
 ---
 
-This guide covers upgrade and migration to version 2.3.0. This guide only covers migration from v1.10.x and later to the current version. If you are upgrading from an earlier version, refer to the migration guide in the `release-1.10.0` branch to upgrade to v1.10.x first, then follow this guide to perform the migration to this version.
+This guide covers upgrade and migration to v2.5.0. This guide only covers migration from v2.3.0 and later to the current version. If you are upgrading from an earlier version, refer to the migration guide for an earlier Harbor version.
+
+* [Upgrade to Harbor v2.3.0](/docs/2.2.0/administration/upgrade/)
+* [Upgrade to Harbor v2.2.0](/docs/2.2.0/administration/upgrade/)
+* [Upgrade to Harbor v2.1.0](/docs/2.1.0/administration/upgrade/)
+* [Upgrade to Harbor v2.0.0](/docs/2.2.0/administration/upgrade/)
+* [Upgrade to Harbor v1.10.0](/docs/1.10/administration/upgrade/)
 
 If you are upgrading a Harbor instance that you deployed with Helm, see [Upgrading Harbor Deployed with Helm](helm-upgrade.md).
 
@@ -13,12 +19,7 @@ Since the migration might alter the database schema and the settings of `harbor.
 ## Important Upgrade Notes
 
 - Again, you MUST backup your data before any data migration.
-- In version 1.10.0, some containers are started by `non-root`. This does not pose problems if you are upgrading an officially released version of Harbor, but if you have deployed a customized instance of Harbor, you might encounter permission issues.
-- In v2.0 the metadata of artifacts are stored in database, when Harbor is started for the first time after the upgrade it will walkthrough the artifacts in registry storage to extract metadata of the artifacts into database.  This process may take relatively long time if there are large number of artifacts in the registry, especially when registry is configured to use external storage like S3.  During this process the Harbor API will not be responsive please check the log of `harbor-core` and `registry` to monitor the process.
-- Harbor v2.2 vulnerability scanning changes
-  - Clair was removed as a default scanner. If you upgrade with Clair as your default scanner, you will no longer be able to run vulnerability scans until a new scanner is installed. It's recommended that you use Trivy as your default scanner or add Clair as an [external scanner](../vulnerability-scanning/pluggable-scanners.md) after upgrade.
-  - Updates were made to the vulnerability database scheme which require you to rescan all images after upgrade. Scan reports from before the upgrade are preserved, but will not be visible to you until you scan all images again. For more information, read how to [Scan All Artifacts](../vulnerability-scanning/scan-all-artifacts/).
-- Harbor v2.3 uses PostgreSQL v13.2. During an upgrade, Harbor will remove the old PostgreSQL data and migrate it to new destination to compatible new version PostgreSQL. You must backup your data before upgrading to v2.3.0.
+- In Harbor v2.5, if you are using an external database, make sure the version of PostgreSQL >= 10.
 
 ## Upgrading Harbor and Migrating Data
 


### PR DESCRIPTION
Signed-off-by: Abigail McCarthy <mabigail@vmware.com>

Based on the release notes for the upcoming 2.5 release, here is the updated upgrade doc.

I've also removed some old information and updated it to point folks to older upgrade pages depending on their version. Related to the info in this issue, https://github.com/goharbor/website/issues/304