### PR TITLE
`disabled` missed `ed` and `"` is  intercalary

### DIFF
--- a/docs/install-config/configure-yml-file.md
+++ b/docs/install-config/configure-yml-file.md
@@ -411,9 +411,9 @@ storage_service:
     tenant: admin
     domain: default
     region: regionOne
-    container: docker_images"
+    container: docker_images
   redirect:
-    disable: false
+    disabled: false
 ```
 
 ## What to Do Next


### PR DESCRIPTION
In storage_service section `ed` of `disabled` missed.
‍`"‍` sign at the end of container name shall be removed.

Signed-off-by: SMHashemi <s.milad.hashemi@gmail.com>