### PR TITLE
Bind host to 0.0.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ prepare:
 
 serve:
 	hugo server \
+		--bind 0.0.0.0 \
 		--buildDrafts \
 		--buildFuture \
 		--disableFastRender


### PR DESCRIPTION
1. Bind host to 0.0.0.0 for `hugo server` command.  Then users can visit the server by `http://localhost:1313` or   `http://<ip>:1313`. The latter is often used for remote access
Signed-off-by: AllForNothing <sshijun@vmware.com>