### PR TITLE
Replaced .0 with .x for doc version drop down

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -21,47 +21,47 @@ youtube_video_id = "4zZiBcvZmgQ"
 alpine_js_version = "2.1.2"
 
 [[params.versions]]
-harborversion = "2.7.0"
+harborversion = "2.7.x"
 helmversion = "1.3"
 branchname = "release-2.7.0"
 
 [[params.versions]]
-harborversion = "2.6.0"
+harborversion = "2.6.x"
 helmversion = "1.3"
 branchname = "release-2.6.0"
 
 [[params.versions]]
-harborversion = "2.5.0"
+harborversion = "2.5.x"
 helmversion = "1.3"
 branchname = "release-2.5.0"
 
 [[params.versions]]
-harborversion = "2.4.0"
+harborversion = "2.4.x"
 helmversion = "1.3"
 branchname = "release-2.4.0"
 
 [[params.versions]]
-harborversion = "2.3.0"
+harborversion = "2.3.x"
 helmversion = "1.3"
 branchname = "release-2.3.0"
 
 [[params.versions]]
-harborversion = "2.2.0"
+harborversion = "2.2.x"
 helmversion = "1.3"
 branchname = "release-2.2.0"
 
 [[params.versions]]
-harborversion = "2.1.0"
+harborversion = "2.1.x"
 helmversion = "1.3"
 branchname = "release-2.1.0"
 
 [[params.versions]]
-harborversion = "2.0.0"
+harborversion = "2.0."
 helmversion = "1.3"
 branchname = "release-2.0.0"
 
 [[params.versions]]
-harborversion = "1.10"
+harborversion = "1.10.x"
 helmversion = "1.3"
 branchname = "release-1.10"
 


### PR DESCRIPTION
Signed-off-by: PaarthAgarwal <paarth.agarwal.mec20@itbhu.ac.in>
Updates the config.toml file to display the version number with .x instead of .0 in the drop-down.
Partially fixes #219. 