### PR TITLE
Update registry landscape table

### DIFF
--- a/docs/build-customize-contribute/registry-landscape.md
+++ b/docs/build-customize-contribute/registry-landscape.md
@@ -11,7 +11,7 @@ This table is maintained by contributions from the Harbor community. If you find
 | Ability to Determine Version of Binaries in Containers | ✓      | ✓                       | ✓       | ✗                                 | ✗                           | ?           | ?        |
 | Artifact Repository (rpms, git, jar, etc)              | ✗      | ✗                       | ✗       | ✗                                 | ✗                           | ✓           | partial  |
 | Audit Logs                                             | ✓      | ✓                       | ✓       | ✓                                 | ✗                           | ✓           | ✓        |
-| Content Trust and Validation                           | ✓      | ✓                       | ✗       | ✗                                 | partial                     | partial     | ✗        |
+| Content Trust and Validation                           | ✓      | ✓                       | ✓       | ✗                                 | partial                     | partial     | ✗        |
 | Custom TLS Certificates                                | ✓      | ✓                       | ✓       | ✗                                 | ✓                           | ✓           | ✓        |
 | Helm Chart Repository Manager                          | ✓      | ✗                       | partial | ✗                                 | ✗                           | ✓           | ✗        |
 | LDAP-based Auth                                        | ✓      | ✓                       | ✓       | partial                           | ✗                           | ✓           | ✓        |
@@ -19,7 +19,7 @@ This table is maintained by contributions from the Harbor community. If you find
 | Metrics       | ✓      | ✓                       | ✓       | ✓                           | ✓                           | ✓           | ✓        |
 | Multi-Tenancy (projects, teams, namespaces, etc)       | ✓      | ✓                       | ✓       | partial                           | ✗                           | ✓           | ✓        |
 | Open Source                                            | ✓      | partial                 | ✓       | ✗                                 | ✓                           | partial     | partial  |
-| Project Quotas (by image count & storage consumption)  | ✓      | ✗                       | ✗       | partial                           | ✗                           | ✗           | ✗        |
+| Project Quotas (by storage consumption)                | ✓      | ✗                       | ✓       | partial                           | ✗                           | ✗           | ✗        |
 | Replication between instances                          | ✓      | ✓                       | ✓       | n/a                               | ✗                           | ✓           | ✗        |
 | Replication between non-instances                      | ✓      | ✗                       | ✓       | n/a                               | ✗                           | ✗           | ✗        |
 | Robot Accounts for Helm Charts                         | ✓      | ✗                       | ✗       | ?                                 | ✗                           | ✗           | ✗        |


### PR DESCRIPTION
This PR updates some project Quay-related features in the registry landscape table.
Some differences have been found in the recent [overview](https://github.com/SovereignCloudStack/standards/pull/212/files) of the open-source container registries within the SCS project.

Find the list of modified Quay features and comments below:

1. _Content Trust and Validation_  

- Quay supports Cosign since [Quay v3.6](https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/use_red_hat_quay/oci-intro#cosign-oci-with-quay) 

- See the print screen from my quick test below: 
![image](https://user-images.githubusercontent.com/17620218/219016758-610df5eb-9591-461d-88e6-dddccd021608.png)
 
2. _Project Quotas (by storage consumption)_

- Support for quota management based on storage consumption is there since [Quay v3.7](https://access.redhat.com/documentation/en-us/red_hat_quay/3.7/html-single/use_red_hat_quay/index#red-hat-quay-quota-management-and-enforcement)

- This row has been adjusted  as Harbor's support for "Project Quota based on number of images" has been removed in v2.0.0.

3. _Upstream Registry Proxy Cache_ 

- Quay supports [proxy cache](https://access.redhat.com/documentation/en-us/red_hat_quay/3.7/html-single/use_red_hat_quay/index#quay-as-cache-proxy)

- This feature is still marked as `Technology Preview`, see the [note](https://access.redhat.com/documentation/en-us/red_hat_quay/3.7/html-single/use_red_hat_quay/index#quay-as-cache-proxy) in the related docs

- This row in the table was filled with the "✓" as I assumed that this table does not evaluate the maturity of mentioned features 

