### PR TITLE
Fix a typo in the compile guide

### DIFF
--- a/docs/build-customize-contribute/compile-guide.md
+++ b/docs/build-customize-contribute/compile-guide.md
@@ -29,7 +29,7 @@ git clone https://github.com/goharbor/harbor
 
 ### Configuration
 
-Copy the file **make/harbor.yml.tmp** to **make/harbor.yml**, and make necessary configuration changes such as hostname, admin password and mail server. Refer to [Harbor Installation and Configuration](../install-config/_index.md) for more info.
+Copy the file **make/harbor.yml.tmpl** to **make/harbor.yml**, and make necessary configuration changes such as hostname, admin password and mail server. Refer to [Harbor Installation and Configuration](../install-config/_index.md) for more info.
 
 ```sh
 cd harbor


### PR DESCRIPTION
The Harbor compile guide, step 3, configuration refers to a `make/harbor.yaml.tmp` file which does not exist the the harbor repo: 
- [website](https://goharbor.io/docs/edge/build-customize-contribute/compile-guide/)
- [github](https://github.com/goharbor/website/blob/main/docs/build-customize-contribute/compile-guide.md#step-3-building-and-installing-harbor)

The file is actually named [`make/harbor.yaml.tmpl`](https://github.com/goharbor/harbor/blob/main/make/harbor.yml.tmpl)