### PR TITLE
Remove duplicated text in replication filters docs

### DIFF
--- a/docs/administration/configuring-replication/create-replication-rules.md
+++ b/docs/administration/configuring-replication/create-replication-rules.md
@@ -28,10 +28,6 @@ A replication endpoint must exist before you create a replication rule. To creat
    * **\***: Matches any sequence of non-separator characters `/`.
    * **\*\***: Matches any sequence of characters, including path separators `/`.
    * **?**: Matches any single non-separator character `/`.
-   * **{alt1,...}**: Matches a sequence of characters if one of the comma-separated alternatives matches. are as follows:
-   * **\***: Matches any sequence of non-separator characters `/`.
-   * **\*\***: Matches any sequence of characters, including path separators `/`.
-   * **?**: Matches any single non-separator character `/`.
    * **{alt1,...}**: Matches a sequence of characters if one of the comma-separated alternatives matches.
 
    **NOTE:** You must add `library` if you want to replicate the official images of Docker Hub. For example, `library/hello-world` matches the official hello-world images.  


### PR DESCRIPTION
The text in harbor page seemed either malformed or duplicated (leftover)

https://goharbor.io/docs/1.10/administration/configuring-replication/create-replication-rules/#:~:text=.%20are%20as%20follows,separated%20alternatives%20matches.

This PR removes duplicated text.