### PR TITLE
Update configure-https.md

### DIFF
--- a/docs/install-config/configure-https.md
+++ b/docs/install-config/configure-https.md
@@ -25,7 +25,7 @@ In a production environment, you should obtain a certificate from a CA. In a tes
    
     ```sh
     openssl req -x509 -new -nodes -sha512 -days 3650 \
-     -subj "/C=CN/ST=Beijing/L=Beijing/O=example/OU=Personal/CN=yourdomain.com" \
+     -subj "/C=CN/ST=Beijing/L=Beijing/O=example/OU=Personal/CN=MyPersonal Root CA" \
      -key ca.key \
      -out ca.crt
     ```


### PR DESCRIPTION
Fix CA common name field to avoid "error yourdomain.com.crt: verification failed"

If we create CA and server certificate with the same CN, on some setups we may get the following error:
```
error 18 at 0 depth lookup: self signed certificate
error yourdomain.com.crt: verification failed
```
This may lead to inoperability of other systems working with the Harbor registry via HTTPS. To solve this issue CN field for CA certificate should be different from CN of the server certificate.

The best practice for creating CAs states the following:
`The certification authority (CA) name should never be the same as the server's computer name (NetBIOS or DNS / hostname)`

Ref: https://social.technet.microsoft.com/wiki/contents/articles/16160.considerations-for-certification-authority-ca-names.aspx