### PR TITLE
Missing artifactory in compatibility list in Configure Proxy Cache page

### DIFF
--- a/docs/administration/configure-proxy-cache/_index.md
+++ b/docs/administration/configure-proxy-cache/_index.md
@@ -17,6 +17,7 @@ Harbor supports proxy caching for the following registries:
    - Google Container Registry
    - Quay
    - Github Container Registry
+   - JFrog Artifactory Registry
 
 {{< /note >}}
 


### PR DESCRIPTION
Hello, 
I found a missing element in compatibility list in Configure Proxy Cache page.
Artifactory support has been added in this [PR](https://github.com/goharbor/harbor/pull/17738).

I fixed it and you might want backport in 2.9.0. 

Thank you !