### PR TITLE
Correct minimum external postgres version requirement in upgrade for edge docs

### DIFF
--- a/docs/administration/upgrade/_index.md
+++ b/docs/administration/upgrade/_index.md
@@ -22,7 +22,7 @@ Since the migration might alter the database schema and the settings of `harbor.
 ## Important Upgrade Notes
 
 - Again, you MUST backup your data before any data migration.
-- In Harbor v2.5, if you are using an external database, make sure the version of PostgreSQL >= 10.
+- In Harbor v2.9, if you are using an external database, make sure the version of PostgreSQL >= 12.
 
 ## Upgrading Harbor and Migrating Data
 


### PR DESCRIPTION
The release notes for harbor v2.9.0 state that postgres must be >= 12. Updating upgrade guide to match this

https://github.com/goharbor/harbor/releases/tag/v2.9.0

See issue https://github.com/goharbor/website/issues/536