### PR TITLE
Convert docker-compose commands to plugin style.

### DIFF
--- a/docs/administration/upgrade/_index.md
+++ b/docs/administration/upgrade/_index.md
@@ -30,7 +30,7 @@ Since the migration might alter the database schema and the settings of `harbor.
 
     ```sh
     cd harbor
-    docker-compose down
+    docker compose down
     ```
 
 1. Back up Harbor's current files so that you can roll back to the current version if necessary.

--- a/docs/administration/upgrade/roll-back-upgrade.md
+++ b/docs/administration/upgrade/roll-back-upgrade.md
@@ -17,7 +17,7 @@ Harbor 2.2 is compiled by Golang 1.15 which deprecated self signed certificate w
 
     ```sh
     cd harbor
-    docker-compose down
+    docker compose down
     ```
 
 2. Remove current Harbor instance.

--- a/docs/administration/vulnerability-scanning/configure-custom-certs.md
+++ b/docs/administration/vulnerability-scanning/configure-custom-certs.md
@@ -37,7 +37,7 @@ In some cases it might be usefull to provide custom certificate auhtority (CA) b
 ```
 1. note the binding which mounts to `/harbor_cust_cert` and add your ca-bundle or the single public-certificates into the mount-location, by copying them.
 1. (opt) if the host-path doesn't fit for your case, you can also configure another path in the docker-compose file. be aware, that you might have to manually change this, if there are changes on new releases of trivy/harbor.
-1. restart your containers (at least trivy-adapter) by using `docker restart trivy-adapter` or `docker-compose restart`. If you changed the bind path, it is necessary to start the services by using `docker-compose up -d`
+1. restart your containers (at least trivy-adapter) by using `docker restart trivy-adapter` or `docker compose restart`. If you changed the bind path, it is necessary to start the services by using `docker compose up -d`
 
 ## Upgrades
 Depending on if you changed the path or not an update might overwrite the folder or mount from a different location. The following process makes sure, you don't run into anything unexpected

--- a/docs/install-config/configure-https.md
+++ b/docs/install-config/configure-https.md
@@ -148,13 +148,13 @@ If you already deployed Harbor with HTTP and want to reconfigure it to use HTTPS
     Your image data remains in the file system, so no data is lost.
 
     ```sh
-    docker-compose down -v
+    docker compose down -v
     ```
 
 1. Restart Harbor:
 
     ```sh
-    docker-compose up -d
+    docker compose up -d
     ```
 
 ## Verify the HTTPS Connection

--- a/docs/install-config/customize-token-service.md
+++ b/docs/install-config/customize-token-service.md
@@ -55,7 +55,7 @@ See [Run the Installer Script](run-installer-script.md) or [Reconfigure Harbor a
 1. Go back to the `make` directory, and start Harbor by using following command:
 
    ```sh
-   docker-compose up -d
+   docker compose up -d
    ```
 
 1. Push and pull images to and from Harbor to check that your own certificate works.

--- a/docs/install-config/reconfigure-manage-lifecycle.md
+++ b/docs/install-config/reconfigure-manage-lifecycle.md
@@ -12,7 +12,7 @@ See the [Docker Compose command-line reference](https://docs.docker.com/compose/
 To stop Harbor, run the following command.
 
 ```sh
-sudo docker-compose stop
+sudo docker compose stop
 Stopping nginx              ... done
 Stopping harbor-portal      ... done
 Stopping harbor-jobservice  ... done
@@ -29,7 +29,7 @@ Stopping harbor-log         ... done
 To restart Harbor, run the following command.
 
 ```sh
-sudo docker-compose start
+sudo docker compose start
 Starting log         ... done
 Starting registry    ... done
 Starting registryctl ... done
@@ -48,7 +48,7 @@ To reconfigure Harbor, perform the following steps.
 1. Stop Harbor.
 
     ```sh
-    sudo docker-compose down -v
+    sudo docker compose down -v
     ```
 
 1. Update `harbor.yml`.
@@ -72,7 +72,7 @@ To reconfigure Harbor, perform the following steps.
 1. Re-create and start the Harbor instance.
 
     ```sh
-    sudo docker-compose up -d
+    sudo docker compose up -d
     ```
 
 ## Other Commands
@@ -80,7 +80,7 @@ To reconfigure Harbor, perform the following steps.
 Remove Harbor's containers but keep all of the image data and Harbor's database files in the file system:
 
 ```sh
-sudo docker-compose down -v
+sudo docker compose down -v
 ```
 
 Remove the Harbor database and image data before performing a clean re-installation:

--- a/docs/install-config/run-installer-script.md
+++ b/docs/install-config/run-installer-script.md
@@ -66,13 +66,13 @@ After you update `daemon.json`, you must restart both Docker Engine and Harbor.
 1. Stop Harbor.
 
     ```sh
-    docker-compose down -v
+    docker compose down -v
     ```
 
 1. Restart Harbor.
 
     ```sh
-    docker-compose up -d
+    docker compose up -d
     ```
 
 ## What to Do Next ##

--- a/docs/install-config/troubleshoot-installation.md
+++ b/docs/install-config/troubleshoot-installation.md
@@ -16,7 +16,7 @@ In addition, Harbor uses `rsyslog` to collect the logs of each container. By def
 If Harbor does not start or functions incorrectly, run the following command to check whether all of Harbor's containers are in the `Up` state.
 
 ```
-sudo docker-compose ps
+sudo docker compose ps
         Name                     Command               State                    Ports
   -----------------------------------------------------------------------------------------------------------------------------
   harbor-core         /harbor/start.sh                 Up


### PR DESCRIPTION
Convert `docker-compose` -> `docker compose` since docker-compose v1 was EOL in July 2023.