### PR TITLE
fix layout of users and partners

### DIFF
--- a/layouts/partials/partners.html
+++ b/layouts/partials/partners.html
@@ -3,8 +3,8 @@
   <div class="columns is-multiline is-variable is-8">
     {{ range $partners }}
     {{ $img := printf "img/logos/users-partners/%s" .logo | relURL }}
-    <div class="column is-one-quarter has-text-centered">
-      <a href="{{ .link }}"><img src="{{ $img }}" alt="{{ .title }} partner logo"></a>
+    <div class="column is-one-quarter has-text-centered" style="display: flex;justify-content: center;flex-wrap: nowrap;align-items: center;">
+      <a href="{{ .link }}"><img src="{{ $img }}" alt="{{ .title }} partner logo" style="max-height: 128px"></a>
     </div>
     {{ end }}
   </div>

--- a/layouts/partials/users.html
+++ b/layouts/partials/users.html
@@ -3,8 +3,8 @@
   <div class="columns is-multiline is-variable is-8">
     {{ range $users }}
     {{ $img := printf "img/logos/users-partners/%s" .logo | relURL }}
-    <div class="column is-one-quarter has-text-centered">
-      <a href="{{ .link }}"><img src="{{ $img }}" alt="{{ .title }} user logo"></a>
+    <div class="column is-one-quarter has-text-centered" style="display: flex;justify-content: center;flex-wrap: nowrap;align-items: center;">
+      <a href="{{ .link }}"><img src="{{ $img }}" alt="{{ .title }} user logo" style="max-height: 128px;margin: 20px;"></a>
     </div>
     {{ end }}
   </div>


### PR DESCRIPTION
This is a fix of the layout on the main page. 

The left side is the current setup and the right side is the new layout. 

What changes is the orientation of the images and the max size of images, so that we don't end up with images that are too small or too big.

<img width="2999" alt="Bildschirmfoto 2024-06-01 um 00 45 51" src="https://github.com/goharbor/website/assets/1492007/5a37bba9-27d2-4d87-a193-9b3c7454125a">
