### PR TITLE
Document NPM_REGISTRY make parameter

### DIFF
--- a/docs/build-customize-contribute/compile-guide.md
+++ b/docs/build-customize-contribute/compile-guide.md
@@ -89,6 +89,7 @@ The `Makefile` contains these configurable parameters:
 | COMPILETAG          | Compile model flag, default: compile_normal (local golang build) |
 | TRIVYFLAG           | Trivy mode flag, default: false                                  |
 | HTTPPROXY           | NPM http proxy for Clarity UI builder                            |
+| NPM_REGISTRY        | NPM registry override                                            |
 | REGISTRYSERVER      | Remote registry server IP address                                |
 | REGISTRYUSER        | Remote registry server user name                                 |
 | REGISTRYPASSWORD    | Remote registry server user password                             |


### PR DESCRIPTION
This is listed in the Makefile but not documented yet. 

Using it solved a problem I was having when building Harbor in an internet-limited environment.

It looks like this variable has been present in the Makefile since the 1.x versions: https://github.com/goharbor/harbor/commit/6fbb77d65a29e41272d7df3ab0cad07bd16de4a9