### PR TITLE
Fix broken HTTPS configuration link in run-installer-script page

### DIFF
--- a/docs/install-config/run-installer-script.md
+++ b/docs/install-config/run-installer-script.md
@@ -29,7 +29,7 @@ docker push reg.yourdomain.com/myproject/myrepo:mytag
 ```
 
 {{< important >}}
-- If your installation of Harbor uses HTTPS, you must provide the Harbor certificates to the Docker client. For information, see [Configure HTTPS Access to Harbor](configure-https.md#provide-the-certificates-to-harbor-and-docker).
+- If your installation of Harbor uses HTTPS, you must provide the Harbor certificates to the Docker client. For information, see [Configure HTTPS Access to Harbor](../configure-https).
 - If your installation of Harbor uses HTTP, you must add the option `--insecure-registry` to your client's Docker daemon and restart the Docker service. For more information, see [Connecting to Harbor via HTTP](#connect-http) below.
 {{< /important >}}
 


### PR DESCRIPTION

### What kind of change does this PR introduce?  
This PR addresses a documentation issue by fixing a broken link in the **run-installer-script** page. The incorrect link, **"Configure HTTPS Access to Harbor"**, located in the **Default installation without Trivy** section, has been replaced with the correct URL to ensure proper navigation.  

### Which issue(s) does this PR fix?  
- Fixes **#620**  

