### PR TITLE
feat(docs): Add warning banner for outdated documentation versions

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -20,6 +20,7 @@ dev_group = "https://lists.cncf.io/g/harbor-dev"
 logo_repo = "https://github.com/cncf/artwork/tree/master/projects/harbor"
 youtube_video_id = "4zZiBcvZmgQ"
 alpine_js_version = "2.1.2"
+latest_version = "v2.13.0"
 
 [[params.versions]]
 harborversion = "2.13.0"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,3 +1,5 @@
+<!-- This is the complete and correct final code for layouts/_default/baseof.html -->
+
 {{ $lang := site.LanguageCode }}
 {{ $home := .IsHome }}
 <!DOCTYPE html>
@@ -22,6 +24,27 @@
       'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-TKWH5SPC');</script>
     <!-- End Analytics -->
+
+    <!-- =================================================================== -->
+    <!-- START: Your Canonical URL Addition -->
+    <!-- =================================================================== -->
+    {{ $isVersioned := "" }}
+    {{ with (findRE `^/docs/([0-9]+\.[0-9]+)/` .RelPermalink) }}
+      {{ $isVersioned = . }}
+    {{ end }}
+    {{ if $isVersioned }}
+      {{ $currentVersionRaw := index (findRE `([0-9]+\.[0-9]+)` .RelPermalink) 0 }}
+      {{ $latestVersionWithV := .Site.Params.latest_version }}
+      {{/* For the canonical URL, we always point to 'main' */}}
+      {{ $canonicalURL := replace .RelPermalink $currentVersionRaw "main" }}
+      <link rel="canonical" href="{{ $canonicalURL | absURL }}">
+    {{ else }}
+      <link rel="canonical" href="{{ .Permalink }}">
+    {{ end }}
+    <!-- =================================================================== -->
+    <!-- END: Your Canonical URL Addition -->
+    <!-- =================================================================== -->
+
   </head>
   <body class="is-page has-navbar-fixed-top">
     <!-- Analytics if (noscript) -->
@@ -30,6 +53,14 @@
     <!-- Analytics if  (noscript) -->
     <main class="is-main">
       {{ partial "navbar.html" . }}
+
+      <!-- =================================================================== -->
+      <!-- START: Your Version Banner Addition -->
+      <!-- =================================================================== -->
+      {{ partial "version-banner.html" . }}
+      <!-- =================================================================== -->
+      <!-- END: Your Version Banner Addition -->
+      <!-- =================================================================== -->
 
       {{ block "main" . }}
       {{ end }}

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,0 +1,23 @@
+<!-- This is the code for the NEW reusable banner: layouts/partials/banner.html -->
+
+{{/*
+  This is a reusable banner component.
+  It expects a dictionary of parameters:
+  - .title: The title of the banner (e.g., "Outdated Documentation").
+  - .message: The body content of the banner. Can contain HTML.
+  - .type: The style of the banner (e.g., "warning", "info", "success", "danger").
+*/}}
+
+<div class="container">
+  <article class="message {{ with .type }}is-{{ . }}{{ else }}is-info{{ end }}">
+    {{ with .title }}
+      <div class="message-header">
+        <p>{{ . }}</p>
+      </div>
+    {{ end }}
+    <div class="message-body">
+      {{ .message | safeHTML }}
+    </div>
+  </article>
+  <br/> <!-- Add a little space after the banner -->
+</div>

--- a/layouts/partials/version-banner.html
+++ b/layouts/partials/version-banner.html
@@ -1,0 +1,28 @@
+<!-- This file now only contains the LOGIC for the outdated docs banner. -->
+<!-- It calls the new reusable "banner.html" partial to do the actual display. -->
+
+{{ $latestVersionWithV := .Site.Params.latest_version }}
+{{ $isVersioned := "" }}
+
+{{/* Use a regex that finds versions like "2.3" OR "2.3.0" */}}
+{{ with (findRE `^/docs/([0-9]+\.[0-9]+(\.[0-9]+)?)/` .RelPermalink) }}
+  {{ $isVersioned = . }}
+{{ end }}
+
+{{ if $isVersioned }}
+  {{ $currentVersionRaw := index (findRE `([0-9]+\.[0-9]+(\.[0-9]+)?)` .RelPermalink) 0 }}
+  {{ $currentVersionWithV := printf "v%s" $currentVersionRaw }}
+
+  {{ if ne $currentVersionWithV $latestVersionWithV }}
+
+    {{/* --- Prepare the message for the banner --- */}}
+    {{ $latestVersionRaw := strings.TrimPrefix "v" $latestVersionWithV }}
+    {{ $latestURL := replace .RelPermalink $currentVersionRaw $latestVersionRaw }}
+    {{ $link := printf `<a href="%s">Click here to go to the same page in the %s docs.</a>` ($latestURL | relURL) $latestVersionWithV }}
+    {{ $message := printf "You are viewing documentation for Harbor <strong>%s</strong>, which is an older version. We recommend using the latest version of the documentation.<br/><br/>%s" $currentVersionWithV $link }}
+
+    {{/* --- Now, call our new reusable banner component --- */}}
+    {{ partial "banner.html" (dict "title" "Outdated Documentation" "message" $message "type" "warning") }}
+
+  {{ end }}
+{{ end }}


### PR DESCRIPTION
Fixes : #657

This pull request addresses a common usability issue where users often land on outdated documentation pages from search engine results. This can cause confusion and lead users to follow incorrect instructions. For example, a search for "harbor tag retention" can direct a user to the v1.10 docs, which may contain outdated information, while the user is likely running a much newer version of Harbor.

A prominent warning banner is now displayed at the top of any documentation page that is not for the latest stable version (currently configured as v2.13.0 ). The banner clearly states that the documentation is outdated.
Most importantly, it provides a direct link to the corresponding page in the latest documentation, allowing for a seamless user transition.

This PR implements a warning banner for outdated documentation versions and adds canonical URLs for better SEO.