### PR TITLE
Revert Change the description of proxy cache when upstream tag is removed

### DIFF
--- a/docs/administration/configure-proxy-cache/_index.md
+++ b/docs/administration/configure-proxy-cache/_index.md
@@ -34,8 +34,7 @@ The next time a user requests that image, Harbor checks the image's latest manif
 * If the image has not been updated in the target registry, the cached image is served from the proxy cache project.
 * If the image has been updated in the target registry, the new image is pulled from the target registry, then served and cached in the proxy cache project.
 * If the target registry is not reachable, the proxy cache project serves the cached image.
-* If the image is no longer in the target registry, but is still in the proxy cache project, the cached image is served from the proxy cache project.
-
+* If the image is no longer in the target registry, no image is served.
 
 As of Harbor v2.1.1, Harbor proxy cache fires a HEAD request to determine whether any layer of a cached image has been updated in the Docker Hub registry. Using this method to check the target registry will not trigger the [Docker Hub rate limiter](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/). If any image layer was updated, the proxy cache will pull the new image, which will count towards the Docker Hub rate limiter.
 


### PR DESCRIPTION

    Previous commit is inconsistent with the system behaviour

This reverts commit 2ee87aebde9d9f91de8be291f722b616434bf7be.