### PR TITLE
Fix Grafana dashboard link in metrics documentation

### DIFF
--- a/docs/administration/metrics/_index.md
+++ b/docs/administration/metrics/_index.md
@@ -122,7 +122,7 @@ To begin accessing your Harbor instance's metrics with Prometheus,
           static_configs:
             - targets: ['<harbor_instance>:<metrics_port>']
       ```
-1. Once you have configured your Prometheus server to collect your Harbor metrics, you can use [Grafana](https://grafana.com/docs/) to visualize your data. An [example Grafana dashboard](https://github.com/goharbor/harbor/blob/main/contrib/grafana-dashborad/metrics-example.json) is available in the Harbor repo to help you get started visualizing Harbor metrics.  
+1. Once you have configured your Prometheus server to collect your Harbor metrics, you can use [Grafana](https://grafana.com/docs/) to visualize your data. An [example Grafana dashboard](https://github.com/goharbor/harbor/blob/main/contrib/grafana-dashboard/metrics-example.json) is available in the Harbor repo to help you get started visualizing Harbor metrics.  
 
 ### From a Kubernetes cluster
 


### PR DESCRIPTION
Corrected the link to the example Grafana dashboard in the documentation.