### PR TITLE
📖 Add KubeStellar Console guided install reference

### DIFF
--- a/docs/install-config/_index.md
+++ b/docs/install-config/_index.md
@@ -28,6 +28,12 @@ If installation fails, see [Troubleshooting Harbor Installation](troubleshoot-in
 
 You can also use Helm to install Harbor on a Kubernetes cluster, to make Harbor highly available. For information about installing Harbor with Helm on a Kubernetes cluster, see [Deploying Harbor with High Availability via Helm](harbor-ha-helm.md).
 
+## Guided Installation via KubeStellar Console
+
+[KubeStellar Console](https://console.kubestellar.io) offers a guided installation mission for Harbor that walks you through the entire deployment process. The guided install includes pre-flight checks, step-by-step instructions, validation of each stage, built-in troubleshooting, and rollback support.
+
+To start the guided Harbor installation, visit: https://console.kubestellar.io/missions/install-harbor
+
 ## Post-Installation Configuration
 
 For information about how to manage your deployed Harbor instance, see [Reconfigure Harbor and Manage the Harbor Lifecycle](reconfigure-manage-lifecycle.md).


### PR DESCRIPTION
## Summary

- Adds a "Guided Installation via KubeStellar Console" section to the Harbor Installation and Configuration documentation
- Links to the [KubeStellar Console guided Harbor install mission](https://console.kubestellar.io/missions/install-harbor), which provides pre-flight checks, step-by-step instructions, validation, built-in troubleshooting, and rollback support
- Related discussion: https://github.com/goharbor/harbor/issues/23006

## Context

KubeStellar Console offers guided installation missions for popular CNCF projects including Harbor. The guided install walks users through the entire Harbor deployment process with automated pre-flight checks, stage-by-stage validation, and rollback capabilities if anything goes wrong.

This PR adds a concise reference in the installation docs so Harbor users can discover this alternative installation experience.

## Changes

- `docs/install-config/_index.md`: Added a new section between "Deploy Harbor on Kubernetes" and "Post-Installation Configuration" with a brief description and link to the guided install mission.