### PR TITLE
Improve search results by filtering by doc version

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -48,6 +48,6 @@
     </main>
 
     {{ partial "footer.html" . }}
-    {{ partial "javascript.html" }}
+    {{ partial "javascript.html" . }}
   </body>
 </html>

--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -1,6 +1,29 @@
 {{ $alpineJsVersion := site.Params.alpine_js_version }}
 <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v{{ $alpineJsVersion }}/dist/alpine-ie11.js" defer></script>
 
+{{ $versions := site.Params.versions }}
+{{ $latest   := (index $versions 0).harborversion }}
+{{ $version  := "" }}
+{{ with .File }}
+  {{ $pathParts := split .Path "/" }}
+  {{ if gt (len $pathParts) 1 }}
+    {{ $version = index $pathParts 1 }}
+  {{ end }}
+{{ end }}
+
+{{/* 
+  Check if $version is a valid doc version (e.g. starts with a digit or is 'edge' or 'latest').
+  If not, or if we are not in the docs section, use the latest harbor version.
+*/}}
+{{ $isDocVersion := false }}
+{{ if and (eq .Section "docs") (ne $version "") }}
+  {{ if or (findRE `^[0-9]` $version) (eq $version "edge") (eq $version "latest") }}
+    {{ $isDocVersion = true }}
+  {{ end }}
+{{ end }}
+
+{{ $docVersion := cond $isDocVersion $version $latest }}
+
 {{/* Algolia DocSearch JS */}}
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 <script type="text/javascript">
@@ -8,7 +31,10 @@
     apiKey: 'a1ac053087a2434d93fa11c329a47adb',
     indexName: 'goharbor',
     inputSelector: '#search-bar',
-    debug: false
+    debug: false,
+    algoliaOptions: {
+      facetFilters: ["version:{{ $docVersion }}"]
+    }
   });
 </script>
 

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -15,6 +15,10 @@
 <meta property="og:title" content="{{ $title }}">
 {{ if $isDoc }}
 <meta property="og:type" content="documentation">
+{{ $version := "" }}{{ with .File }}{{ $version = index (split .Path "/") 1 }}{{ end }}
+{{ if or (findRE `^[0-9]` $version) (eq $version "edge") (eq $version "latest") }}
+<meta name="docsearch:version" content="{{ $version }}" />
+{{ end }}
 {{ end }}
 <meta property="og:url" content="{{ .Permalink }}">
 <meta property="og:locale" content="en_US">


### PR DESCRIPTION
Hey everyone,

I saw the message on Slack (https://cloud-native.slack.com/archives/CC1E09J6S/p1777501279083679) about the search results being a bit confusing because they show every doc version at once. I wanted to help out, so I've put together this fix for #626.

I've updated the Algolia DocSearch initialization to automatically filter results based on the version of the docs the user is currently viewing. If you're on the homepage or other non-versioned pages, it'll default to showing results for the latest stable version. 

I also added a docsearch:version meta tag to the doc pages to help the crawler keep things organized in the future.

Let me know what you think!