### PR TITLE
Fix dark mode text contrast

### DIFF
--- a/assets/sass/dark-mode.sass
+++ b/assets/sass/dark-mode.sass
@@ -41,7 +41,7 @@
   
   // Text colors
   --color-text: #e0e0e0
-  --color-text-strong: #ffffff
+  --color-text-strong: #f5f7fa
   --color-text-light: #b0b0b0
   
   // Brand colors (adjusted for better contrast on dark backgrounds)
@@ -205,6 +205,24 @@
       color: var(--color-text-strong) !important
     
     p, li, td, th
+      color: var(--color-text) !important
+
+    strong,
+    b,
+    .has-text-weight-bold,
+    .has-text-weight-semibold
+      color: var(--color-text-strong) !important
+
+    a
+      strong,
+      b,
+      .has-text-weight-bold,
+      .has-text-weight-semibold
+        color: inherit !important
+
+    blockquote
+      background-color: var(--color-background-bis) !important
+      border-left-color: var(--color-border) !important
       color: var(--color-text) !important
   
   // Links
@@ -390,4 +408,3 @@
     .card
       background-color: white !important
       color: black !important
-


### PR DESCRIPTION
## Summary
- Improve dark mode readability for blog and docs content by overriding bold and semibold text colors in rendered content.
- Keep bold links inheriting link color and make blockquotes use dark-theme surfaces.

Fixes #701

## Screenshots 
| Before | After |
| --- | --- |
| [<img width="1900" height="1041" alt="Before dark mode text contrast" src="https://github.com/user-attachments/assets/8ba38fad-6e4c-4ccf-8cbd-9d6402876aed" />](https://goharbor.io/blog/harbor-at-kubecon-amsterdam-2026/) | [<img width="1900" height="1041" alt="After dark mode text contrast" src="https://github.com/user-attachments/assets/ab2cf072-146f-4820-9f2b-4daf96afa1f5" />](https://deploy-preview-723--goharbor-io.netlify.app/blog/harbor-at-kubecon-amsterdam-2026/) |