### PR TITLE
chore: Update website footer to new LF Projects Series LLC trademark …

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -77,10 +77,8 @@
       <br/>
 
       <p>
-        &copy; {{ $year }} <a href="https://linuxfoundation.org" target="_blank">The Linux Foundation</a>. All
-        rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of
-        trademarks of The Linux Foundation, please see our <a
-        href="https://linuxfoundation.org/trademark-usage" target="_blank">Trademark Usage</a> page.
+        Copyright Harbor a Series of LF Projects, LLC<br/>
+        For website terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org/policies/" target="_blank">https://lfprojects.org/policies/</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
## What this PR does ?

This PR updates the project's website footer to include the new Linux Foundation projects trademark disclaimer as required by the CNCF guidelines. The project has been converted to a Series of LF Projects, LLC, and this change reflects the correct copyright and policy links.

### Acceptance Criteria met:
- [x] Footer links to LF Projects policies (`https://lfprojects.org/policies/`)
- [x] Footer includes the "A Series of LF Projects, LLC" wording

Fixes #720