### PR TITLE
docs: Add Carbon Black Adapter to Compatibility List

### DIFF
--- a/docs/install-config/harbor-compatibility-list.md
+++ b/docs/install-config/harbor-compatibility-list.md
@@ -51,6 +51,7 @@ This document provides compatibility information for all Harbor components.
 | [TensorSecurity](https://github.com/tensorsecurity/harbor-scanner) |![TensorSecurity](../../img/scanners/tensorsecurity.png) | TensorSecurity | ![Y](../../img/replication-adapters/right.png) |  | v2.2.0 |
 | [ArksecScanner](https://github.com/arksec-cn)    |![Arksec](../../img/scanners/arksec.png)| Arksec    |![Y](../../img/replication-adapters/right.png)| | v2.4.0 |
 | [Cyberwatch](https://github.com/Cyberwatch)    |![Cyberwatch](../../img/scanners/cyberwatch.png)| [Cyberwatch](https://cyberwatch.fr/integrate-with-harbor-scans)    |![Y](../../img/replication-adapters/right.png)|  | v2.8.0 |
+| [Carbon Black](https://github.com/vmware/carbon-black-adapter-for-harbor) | Carbon Black | VMware |![Y](../../img/replication-adapters/right.png)| | v2.0.0 |
 
 
 {{< note >}}


### PR DESCRIPTION
## What this PR does ?

This PR adds an entry to the Scanner Adapters section of the Harbor Compatibility List to reflect compatibility with the VMware Carbon Black Adapter for Harbor (v2.0.0).

### Changes made:
- Added Carbon Black Adapter to `docs/install-config/harbor-compatibility-list.md`.
- Included the relevant GitHub repository link and provider information as requested.

Fixes #651