### PR TITLE
fix: add rel='noopener noreferrer' to external links

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -16,7 +16,7 @@
           {{ $isHere := eq .URL $here }}
           {{ $isExternal := hasPrefix .URL "http" }}
             <li>
-              <a class="" href="{{ .URL }}"{{ if $isExternal }} target="_blank"{{ end }} data-proofer-ignore>
+              <a class="" href="{{ .URL }}"{{ if $isExternal }} target="_blank" rel="noopener noreferrer"{{ end }} data-proofer-ignore>
               {{ .Name }}
               </a>
             </li>

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -7,4 +7,4 @@
 {{- with $url.Fragment }}{{ $fragment = printf "#%s" . }}{{ end -}}
 {{- with .Page.GetPage $url.Path }}{{ $link = printf "%s%s" .RelPermalink $fragment }}{{ end }}{{ end -}}
 {{- end -}}
-<a href="{{ $link | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}{{ if $isRemote }} target="_blank"{{ end }}>{{- .Text | safeHTML -}}</a>
+<a href="{{ $link | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}{{ if $isRemote }} target="_blank" rel="noopener noreferrer"{{ end }}>{{- .Text | safeHTML -}}</a>

--- a/layouts/partials/blog/posts.html
+++ b/layouts/partials/blog/posts.html
@@ -57,7 +57,7 @@
             <div class="media-content">
               <div class="content">
                 <p class="title is-size-5 is-size-6-mobile is-spaced">
-                  <a href="{{ .link }}" target="_blank">
+                  <a href="{{ .link }}" target="_blank" rel="noopener noreferrer">
                     {{ .title }}
                   </a>
                 </p>
@@ -68,7 +68,7 @@
               </div>
             </div>
             <div class="media-right">
-              <a class="has-text-secondary" href="{{ .link }}" target="_blank">
+              <a class="has-text-secondary" href="{{ .link }}" target="_blank" rel="noopener noreferrer">
                 <span class="icon">
                   <i class="fas fa-external-link-alt"></i>
                 </span>

--- a/layouts/partials/cli-docs/sidebar.html
+++ b/layouts/partials/cli-docs/sidebar.html
@@ -28,7 +28,7 @@
     </p>
 
     <div class="buttons are-small">
-      <a class="button is-black" href="{{ $pageSourceUrl }}" target="_blank">
+      <a class="button is-black" href="{{ $pageSourceUrl }}" target="_blank" rel="noopener noreferrer">
         <span class="icon">
           <i class="fab fa-github"></i>
         </span>
@@ -37,7 +37,7 @@
         </span>
       </a>
 
-      <a class="button is-black" href="{{ $issues }}" target="_blank">
+      <a class="button is-black" href="{{ $issues }}" target="_blank" rel="noopener noreferrer">
         <span class="icon">
           <i class="fab fa-github"></i>
         </span>

--- a/layouts/partials/docs/sidebar.html
+++ b/layouts/partials/docs/sidebar.html
@@ -30,7 +30,7 @@
     </p>
 
     <div class="buttons are-small">
-      <a class="button is-black" href="{{ $pageSourceUrl }}" target="_blank">
+      <a class="button is-black" href="{{ $pageSourceUrl }}" target="_blank" rel="noopener noreferrer">
         <span class="icon">
           <i class="fab fa-github"></i>
         </span>
@@ -39,7 +39,7 @@
         </span>
       </a>
 
-      <a class="button is-black" href="{{ $issues }}" target="_blank">
+      <a class="button is-black" href="{{ $issues }}" target="_blank" rel="noopener noreferrer">
         <span class="icon">
           <i class="fab fa-github"></i>
         </span>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -9,7 +9,7 @@
 
       <div class="column">
         <div>
-          <a class="has-text-black is-small" target="_blank" href="{{ site.Params.github }}">
+          <a class="has-text-black is-small" target="_blank" rel="noopener noreferrer" href="{{ site.Params.github }}">
           <span class="icon">
             <i class="fab fa-github"></i>
           </span>
@@ -19,7 +19,7 @@
           </a>
         </div>
         <div>
-          <a class="has-text-black is-small" target="_blank" href="{{ site.Params.status_page }}">
+          <a class="has-text-black is-small" target="_blank" rel="noopener noreferrer" href="{{ site.Params.status_page }}">
             <span class="icon">
               <i class="fa-solid fa-gauge"></i>
             </span>
@@ -29,7 +29,7 @@
           </a>
         </div>
         <div>
-          <a class="has-text-black is-small" target="_blank" href="{{ site.Params.logo_repo }}">
+          <a class="has-text-black is-small" target="_blank" rel="noopener noreferrer" href="{{ site.Params.logo_repo }}">
           <span class="icon">
             <i class="fa fa-palette"></i>
           </span>
@@ -43,7 +43,7 @@
 
       <div class="column">
         <div>
-          <a class="has-text-black is-small" target="_blank" href="{{ site.Params.slack }}">
+          <a class="has-text-black is-small" target="_blank" rel="noopener noreferrer" href="{{ site.Params.slack }}">
           <span class="icon">
             <i class="fab fa-slack"></i>
           </span>
@@ -53,7 +53,7 @@
           </a>
         </div>
         <div>
-          <a class="has-text-black is-small" target="_blank"
+          <a class="has-text-black is-small" target="_blank" rel="noopener noreferrer"
              href="https://twitter.com/{{ site.Params.twitter }}">
           <span class="icon">
             <i class="fab fa-twitter"></i>
@@ -71,16 +71,16 @@
     <div class="is-size-6 has-text-black has-text-weight-light">
       <p>
         &copy; Harbor Authors {{ $year}} | Documentation Distributed under <a
-        href="https://creativecommons.org/licenses/by/4.0/" target="_blank">CC-BY-4.0</a>
+        href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener noreferrer">CC-BY-4.0</a>
       </p>
 
       <br/>
 
       <p>
-        &copy; {{ $year }} <a href="https://linuxfoundation.org" target="_blank">The Linux Foundation</a>. All
+        &copy; {{ $year }} <a href="https://linuxfoundation.org" target="_blank" rel="noopener noreferrer">The Linux Foundation</a>. All
         rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of
         trademarks of The Linux Foundation, please see our <a
-        href="https://linuxfoundation.org/trademark-usage" target="_blank">Trademark Usage</a> page.
+        href="https://linuxfoundation.org/trademark-usage" target="_blank" rel="noopener noreferrer">Trademark Usage</a> page.
       </p>
     </div>
   </div>

--- a/layouts/partials/home/hero.html
+++ b/layouts/partials/home/hero.html
@@ -23,7 +23,7 @@
               </span>
             </a>
     
-            <a class="button is-white is-outlined is-inverted has-text-weight-bold" href="https://github.com/goharbor/harbor/releases" target="_blank">
+            <a class="button is-white is-outlined is-inverted has-text-weight-bold" href="https://github.com/goharbor/harbor/releases" target="_blank" rel="noopener noreferrer">
               <span class="icon has-text-secondary">
                 <i class="fas fa-cloud-download-alt"></i>
               </span>

--- a/layouts/partials/home/project.html
+++ b/layouts/partials/home/project.html
@@ -48,7 +48,7 @@
         <br />
 
         <div class="buttons">
-          <a class="button is-twitter-blue" href="/community" target="_blank">
+          <a class="button is-twitter-blue" href="/community" target="_blank" rel="noopener noreferrer">
             <span class="icon">
               <i class="fas fa-users"></i>
             </span>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -51,7 +51,7 @@
         {{ $name := .Name }}
         {{ $isHere := eq .URL $here }}
         {{ $isExternal := hasPrefix .URL "http" }}
-        <a class="navbar-item has-text-weight-bold{{ if $isHere }} is-active{{ end }}" href="{{ .URL }}"{{ if $isExternal }} target="_blank"{{ end }} data-proofer-ignore>
+        <a class="navbar-item has-text-weight-bold{{ if $isHere }} is-active{{ end }}" href="{{ .URL }}"{{ if $isExternal }} target="_blank" rel="noopener noreferrer"{{ end }} data-proofer-ignore>
           {{ $name }}
         </a>
         {{ end }}

--- a/layouts/partials/social-buttons.html
+++ b/layouts/partials/social-buttons.html
@@ -1,17 +1,17 @@
 <div class="buttons">
-  <a class="button is-small is-black is-outlined" target="_blank" href="{{ site.Params.github }}" aria-label="GitHub">
+  <a class="button is-small is-black is-outlined" target="_blank" rel="noopener noreferrer" href="{{ site.Params.github }}" aria-label="GitHub">
     <span class="icon">
       <i class="fab fa-github"></i>
     </span>
   </a>
 
-  <a class="button is-small is-twitter-blue" target="_blank" href="https://twitter.com/{{ site.Params.twitter }}" aria-label="Twitter">
+  <a class="button is-small is-twitter-blue" target="_blank" rel="noopener noreferrer" href="https://twitter.com/{{ site.Params.twitter }}" aria-label="Twitter">
     <span class="icon">
       <i class="fab fa-twitter"></i>
     </span>
   </a>
 
-  <a class="button is-small is-slack-green" target="_blank" href="{{ site.Params.slack }}" aria-label="Slack">
+  <a class="button is-small is-slack-green" target="_blank" rel="noopener noreferrer" href="{{ site.Params.slack }}" aria-label="Slack">
     <span class="icon">
       <i class="fab fa-slack"></i>
     </span>

--- a/layouts/shortcodes/community-info.html
+++ b/layouts/shortcodes/community-info.html
@@ -47,7 +47,7 @@
           </h3>
 
           <p>
-            Read, comment, or add agenda items on the <a href="https://hackmd.io/@harbor/r14BkYaOa" target="_blank">meeting notes</a> and add our calendar and subscribe at <a href="https://lists.cncf.io/g/harbor-users" target="_blank">our mailing list</a> to get the latest Harbor news, what we're working on, and provide suggestions and feedback.
+            Read, comment, or add agenda items on the <a href="https://hackmd.io/@harbor/r14BkYaOa" target="_blank" rel="noopener noreferrer">meeting notes</a> and add our calendar and subscribe at <a href="https://lists.cncf.io/g/harbor-users" target="_blank" rel="noopener noreferrer">our mailing list</a> to get the latest Harbor news, what we're working on, and provide suggestions and feedback.
           </p>
         </div>
 
@@ -62,7 +62,7 @@
           </h3>
 
           <p>
-            All Harbor community meetings are recorded and added to our <a href="https://www.youtube.com/playlist?list=PLgInP-D86bCwTC0DYAa1pgupsQIAWPomv" target="_blank">YouTube playlist</a>.
+            All Harbor community meetings are recorded and added to our <a href="https://www.youtube.com/playlist?list=PLgInP-D86bCwTC0DYAa1pgupsQIAWPomv" target="_blank" rel="noopener noreferrer">YouTube playlist</a>.
           </p>
         </div>
       </div>
@@ -83,7 +83,7 @@
           </h3>
 
           <p>
-            See all the meeting information and add our planned calendar over at <a href="https://github.com/goharbor/community/wiki/Harbor-Community-Meetings" target="_blank">our meeting notes and agenda</a>. All meetings will be recorded and upload to <a href="https://www.youtube.com/playlist?list=PLgInP-D86bCxeNorqeaVlJMv_4x95Le7x" target="_blank">YouTube</a>.
+            See all the meeting information and add our planned calendar over at <a href="https://github.com/goharbor/community/wiki/Harbor-Community-Meetings" target="_blank" rel="noopener noreferrer">our meeting notes and agenda</a>. All meetings will be recorded and upload to <a href="https://www.youtube.com/playlist?list=PLgInP-D86bCxeNorqeaVlJMv_4x95Le7x" target="_blank" rel="noopener noreferrer">YouTube</a>.
           </p>
         </div>
 

--- a/layouts/shortcodes/social.html
+++ b/layouts/shortcodes/social.html
@@ -59,7 +59,7 @@
           </h3>
 
           <p>
-            Join Harbor's user email group at <a href="https://lists.cncf.io/g/harbor-users" target="_blank">https://lists.cncf.io/g/harbor-users</a> to get Harbor's news, features, and releases, or to provide suggestions and feedback.
+            Join Harbor's user email group at <a href="https://lists.cncf.io/g/harbor-users" target="_blank" rel="noopener noreferrer">https://lists.cncf.io/g/harbor-users</a> to get Harbor's news, features, and releases, or to provide suggestions and feedback.
           </p>
         </div>
 
@@ -74,7 +74,7 @@
           </h3>
 
           <p>
-            Join Harbor's developer group at <a href="https://lists.cncf.io/g/harbor-dev" target="_blank">https://lists.cncf.io/g/harbor-dev</a> for updates related to development and contribution.
+            Join Harbor's developer group at <a href="https://lists.cncf.io/g/harbor-dev" target="_blank" rel="noopener noreferrer">https://lists.cncf.io/g/harbor-dev</a> for updates related to development and contribution.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
All external links using `target="_blank"` across the site's partials, shortcodes, and render hooks were missing the `rel="noopener noreferrer"` attribute, exposing the site to reverse tabnapping attacks and minor performance issues. This PR fixes all affected files.

Closes #726

## Changes Made
Added `rel="noopener noreferrer"` to all `target="_blank"` links in the following files:

- `layouts/partials/social-buttons.html` — GitHub, Twitter, Slack links
- `layouts/partials/navbar.html` — External top menu links
- `layouts/partials/home/hero.html` — Download releases button
- `layouts/partials/home/project.html` — Community link
- `layouts/partials/footer.html` — GitHub, Status Page, Logos, Slack, Twitter, CC-BY-4.0 License, The Linux Foundation, Trademark Usage links
- `layouts/partials/docs/sidebar.html` — GitHub source & issues links
- `layouts/partials/cli-docs/sidebar.html` — GitHub source & issues links
- `layouts/partials/blog/posts.html` — External blog links
- `layouts/_default/_markup/render-link.html` — Markdown render hook external links
- `layouts/404.html` — External menu links on 404 page
- `layouts/shortcodes/community-info.html` — Meeting notes, mailing list, YouTube links
- `layouts/shortcodes/social.html` — Distribution list links

## Before & After
Before
```html
<a href="https://example.com" target="_blank">Link</a>
```
After
```html
<a href="https://example.com" target="_blank" rel="noopener noreferrer">Link</a>
```

## Why It Matters
- **Security** — Prevents reverse tabnapping attacks where a newly opened tab could access `window.opener` and redirect the original page to a malicious URL
- **Privacy** — `noreferrer` stops the browser from sending the `Referer` header, preventing the origin URL from leaking to external sites
- **Performance** — `noopener` ensures the new tab runs in a separate process, improving performance in some browsers

## References
- [MDN Web Docs — Link types: noopener](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noopener)
- [web.dev — Links to cross-origin destinations are unsafe](https://web.dev/articles/external-anchors-use-rel-noopener)

## Checklist
- [x] All `target="_blank"` links now include `rel="noopener noreferrer"`
- [x] No existing functionality or styling affected
- [x] Changes verified across all affected partials, shortcodes, and render hooks