### PR TITLE
docs: add 2.15.0 documentation to website menu

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -22,6 +22,11 @@ youtube_video_id = "4zZiBcvZmgQ"
 alpine_js_version = "2.1.2"
 
 [[params.versions]]
+harborversion = "2.15.0"
+helmversion = "1.19"
+branchname = "release-2.15.0"
+
+[[params.versions]]
 harborversion = "2.14.0"
 helmversion = "1.18"
 branchname = "release-2.14.0"

--- a/docs/administration/upgrade/_index.md
+++ b/docs/administration/upgrade/_index.md
@@ -3,8 +3,10 @@ title: Upgrade Harbor and Migrate Data
 weight: 45
 ---
 
-This guide covers upgrade and migration to v2.14.0. This guide only covers migration from v2.11.0 and later to the current version. If you are upgrading from an earlier version, refer to the migration guide for an earlier Harbor version.
+This guide covers upgrade and migration to v2.15.0. This guide only covers migration from v2.11.0 and later to the current version. If you are upgrading from an earlier version, refer to the migration guide for an earlier Harbor version.
 
+* [Upgrade to Harbor v2.14.0](/docs/2.14.0/administration/upgrade/)
+* [Upgrade to Harbor v2.13.0](/docs/2.13.0/administration/upgrade/)
 * [Upgrade to Harbor v2.12.0](/docs/2.12.0/administration/upgrade/)
 * [Upgrade to Harbor v2.11.0](/docs/2.11.0/administration/upgrade/)
 * [Upgrade to Harbor v2.10.0](/docs/2.10.0/administration/upgrade/)

--- a/docs/install-config/harbor-compatibility-list.md
+++ b/docs/install-config/harbor-compatibility-list.md
@@ -51,6 +51,7 @@ This document provides compatibility information for all Harbor components.
 | [TensorSecurity](https://github.com/tensorsecurity/harbor-scanner) |![TensorSecurity](../../img/scanners/tensorsecurity.png) | TensorSecurity | ![Y](../../img/replication-adapters/right.png) |  | v2.2.0 |
 | [ArksecScanner](https://github.com/arksec-cn)    |![Arksec](../../img/scanners/arksec.png)| Arksec    |![Y](../../img/replication-adapters/right.png)| | v2.4.0 |
 | [Cyberwatch](https://github.com/Cyberwatch)    |![Cyberwatch](../../img/scanners/cyberwatch.png)| [Cyberwatch](https://cyberwatch.fr/integrate-with-harbor-scans)    |![Y](../../img/replication-adapters/right.png)|  | v2.8.0 |
+| [Carbon Black](https://github.com/vmware/carbon-black-adapter-for-harbor) | Carbon Black | VMware |![Y](../../img/replication-adapters/right.png)| | v2.0.0 |
 
 
 {{< note >}}


### PR DESCRIPTION
Fixes #717

### Description
This PR addresses the missing documentation for Harbor v2.15.0 on the website by exposing the 2.15.0 release in the documentation dropdown menu.

**Changes included:**
- Added `2.15.0` (with helm version `1.19`) to the `[[params.versions]]` list in `config.toml` so it populates correctly in the website navigation.
- Updated the historical upgrade guide index (`docs/administration/upgrade/_index.md`) to reflect `v2.15.0` as the current version target and added the missing `v2.14.0` and `v2.13.0` upgrade links to the historical list.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update (a change to documentation pages)
- [ ] New feature (non-breaking change which adds functionality)

### Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/goharbor/website/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have signed off my commits using the `git commit -s` flag.