### PR TITLE
docs: fix .cer/.cert extension mismatch in Docker daemon trust config

### DIFF
--- a/docs/install-config/configure-https.md
+++ b/docs/install-config/configure-https.md
@@ -109,7 +109,7 @@ After generating the `ca.crt`, `yourdomain.com.crt`, and `yourdomain.com.key` fi
     To allow the Docker client to push and pull images, the Docker daemon must also trust the certificate so ,convert your server certificate from .crt to .cert, as the Docker daemon requires this extension.
 
     ```sh
-    openssl x509 -inform PEM -in yourdomain.com.crt -out yourdomain.com.cer
+    openssl x509 -inform PEM -in yourdomain.com.crt -out yourdomain.com.cert
     ```
     Next, create a dedicated directory for your Harbor domain and copy all three certificate files into it.
 


### PR DESCRIPTION
## What

Fixes goharbor/harbor#23534 — corrects a mismatch between the documented
certificate extension (`.cert`) and the extension actually produced by
the example OpenSSL command (`.cer`) in the "Configure the Docker Daemon
to Trust the Certificate" section of the HTTPS configuration guide.

## Why

The docs state that the Docker daemon requires the `.cert` extension,
but the example command generates a `.cer` file:

    openssl x509 -inform PEM -in yourdomain.com.crt -out yourdomain.com.cer

A reader who copies the command as written ends up with a `.cer` file,
which Docker's `certs.d` certificate loader does not recognize, while
the very next step in the same doc copies `yourdomain.com.cert` into
`/etc/docker/certs.d/`. This mismatch causes copy-paste failures that
surface later as an unrelated-looking
`x509: certificate signed by unknown authority` error.

Note for reviewers: older release branches (e.g. release-2.1.0,
release-2.3.0) have this command correct as `.cert` this appears to
be a regression introduced at some point on `main`.

## Change

One-line fix: corrected the `-out` filename in the example command from
`.cer` to `.cert`, matching the surrounding prose and the subsequent
`cp` commands.

## Additional context (re: issue's follow-up question)

The issue also asks whether `.cert` is a hard Docker requirement on
certificate *content*, or a *naming convention*. It's the latter
Docker's `certs.d` loader (`/etc/docker/certs.d/<registry>/`)
distinguishes files purely by filename suffix (`ca.crt` for CA certs,
`*.cert` for the client cert, `*.key` for the key); the underlying PEM
format is identical regardless of extension. Not adding this to the
doc body in this PR to keep the diff minimal per the incremental-PR
guidance in CONTRIBUTING.md — happy to add a clarifying note as a
follow-up if maintainers want it inline.

Closes goharbor/harbor#23534