### PR TITLE
docs: update reconfiguration command

### DIFF
--- a/docs/install-config/reconfigure-manage-lifecycle.md
+++ b/docs/install-config/reconfigure-manage-lifecycle.md
@@ -72,7 +72,7 @@ To reconfigure Harbor, perform the following steps.
 1. Re-create and start the Harbor instance.
 
     ```sh
-    sudo docker compose up -d
+    sudo docker compose up -d --force-recreate
     ```
 
 ## Other Commands


### PR DESCRIPTION
## What this PR does

Updates the reconfiguration documentation to use:

```sh
sudo docker compose up -d --force-recreate
```

instead of:

```sh
sudo docker compose up -d
```

This ensures the containers are recreated after configuration changes, preventing inconsistent image state during the stop/start workflow.

## Why

Without `--force-recreate`, existing containers may be reused, which can lead to unexpected behavior after reconfiguration.

## Testing

- Documentation change only.