### PR TITLE
feat: add Harbor ecosystem page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -155,9 +155,14 @@ url = "/community"
 weight = 3
 
 [[menu.main]]
+name = "Ecosystem"
+url = "/ecosystem"
+weight = 4
+
+[[menu.main]]
 name = "Blog"
 url = "/blog"
-weight = 4
+weight = 5
 
 [outputs]
 home = [ "HTML", "REDIRECTS" ]

--- a/content/ecosystem.md
+++ b/content/ecosystem.md
@@ -2,6 +2,6 @@
 title: Ecosystem
 ---
 
-Welcome to the Harbor Ecosystem! Here you will find community projects, extensions, and integrations that enhance and build upon Harbor.
+To suggest an actively maintained project, please open a pull request against the [Harbor website repository](https://github.com/goharbor/website).
 
 {{< ecosystem >}}

--- a/content/ecosystem.md
+++ b/content/ecosystem.md
@@ -1,0 +1,7 @@
+---
+title: Ecosystem
+---
+
+Welcome to the Harbor Ecosystem! Here you will find community projects, extensions, and integrations that enhance and build upon Harbor.
+
+{{< ecosystem >}}

--- a/data/ecosystem.yaml
+++ b/data/ecosystem.yaml
@@ -1,12 +1,88 @@
-- title: Harbor Helm Chart
-  description: The official Helm chart for deploying Harbor on Kubernetes clusters.
-  link: https://github.com/goharbor/harbor-helm
-- title: Terraform Provider for Harbor
-  description: A Terraform provider for managing Harbor resources like projects, users, and registries.
-  link: https://github.com/goharbor/terraform-provider-harbor
-- title: Harbor Next
-  description: The next generation of Harbor projects and architecture.
-  link: https://github.com/container-registry/harbor-next
-- title: Harbor Satellite
-  description: A lightweight Harbor extension for edge deployments and proxying.
-  link: https://github.com/container-registry/harbor-satellite
+- category: Featured projects
+  description: Projects closely connected to Harbor's development and deployment.
+  projects:
+    - title: Harbor Next
+      description: The next generation of Harbor projects and architecture.
+      link: https://github.com/container-registry/harbor-next
+    - title: Harbor Helm Chart
+      description: The official Helm chart for deploying Harbor on Kubernetes clusters.
+      link: https://github.com/goharbor/harbor-helm
+    - title: Terraform Provider for Harbor
+      description: A Terraform provider for managing Harbor resources like projects, users, and registries.
+      link: https://github.com/goharbor/terraform-provider-harbor
+    - title: Harbor Satellite
+      description: A lightweight Harbor extension for edge deployments and proxying.
+      link: https://github.com/container-registry/harbor-satellite
+
+- category: Command-line and repository workflows
+  description: Tools for working with Harbor and synchronizing registry content.
+  projects:
+    - title: Harbor CLI
+      description: Official Harbor CLI
+      link: https://github.com/goharbor/harbor-cli
+    - title: Charts-Syncer
+      description: Sync chart packages and associated container images between chart repositories.
+      link: https://github.com/bitnami-labs/charts-syncer
+    - title: Helm Chart OCI Proxy
+      description: Proxy and transform Helm Chart into OCI images on the fly.
+      link: https://github.com/container-registry/helm-charts-oci-proxy
+    - title: Harbor Sync
+      description: Harbor Sync allows you to synchronize your Harbor robot accounts with your Kubernetes cluster.
+      link: https://github.com/moolen/harbor-sync
+    - title: docker-pushrm
+      description: Update your Harbor project README with a simple CLI.
+      link: https://github.com/christian-korneck/docker-pushrm
+    - title: GitHub Action for docker-pushrm
+      description: GitHub Action on top of docker-pushrm allowing you to update the README of a container repo.
+      link: https://github.com/christian-korneck/update-container-description-action
+    - title: CLI for Harbor
+      description: A community created Harbor CLI written in golang.
+      link: https://github.com/hinyinlam/cli-for-harbor
+
+- category: Security and observability
+  description: Scanners and monitoring tools for Harbor.
+  projects:
+    - title: Harbor Scanner Adapter for Trivy
+      description: Allows Harbor to use Trivy for providing static analysis of vulnerabilities in container images.
+      link: https://github.com/aquasecurity/harbor-scanner-trivy
+    - title: Harbor Scanner Adapter for Aqua Enterprise
+      description: Allows Harbor to use Aqua Enterprise ad hoc scanning feature for providing static analysis of vulnerabilities.
+      link: https://github.com/aquasecurity/harbor-scanner-aqua
+    - title: Harbor Vulnerabilities Exporter
+      description: Prometheus exporter that collects vulnerability information for the latest pushed images.
+      link: https://github.com/NCCloud/harbor-vulnerabilities-exporter
+
+- category: Integrations and operations
+  description: Infrastructure and deployment automation tools.
+  projects:
+    - title: harbor-container-webhook
+      description: Mutating webhook for Kubernetes, which rewrites container images to use Harbor's proxy cache.
+      link: https://github.com/indeedeng-alpha/harbor-container-webhook
+    - title: Crossplane Harbor Provider
+      description: Crossplane provider for Harbor based on terraform-provider-harbor.
+      link: https://github.com/globallogicuki/provider-harbor
+    - title: Pulumi Harbor Provider
+      description: Manage Harbor resources with Pulumi, using the Terraform Harbor Provider under the hood.
+      link: https://github.com/pulumiverse/pulumi-harbor
+    - title: Using Kyverno and Harbor to safeguard production systems
+      description: Rewrites image references to use an internal Harbor proxy cache for approved external registries.
+      link: https://github.com/jvanzyl/kyverno-registries
+    - title: Harbor Example - Terraform/AWS
+      description: A quick way to build an example or demo harbor instance in AWS with optional Route 53 DNS and SSL.
+      link: https://github.com/bdausses/harbor-registry-example-aws
+    - title: Harbor Day 2 Operator
+      description: Operator for automated managment of existing harbor instances using python harbor-api.
+      link: https://github.com/steadforce/harbor-day2-operator
+
+- category: Client SDKs
+  description: Libraries for interacting with the Harbor API.
+  projects:
+    - title: Python Client API
+      description: Python Client API, generated from OpenAPI.
+      link: https://github.com/container-registry/harbor-python-client-api
+    - title: Go Client Library
+      description: '"Official" Client library with golang for accessing Harbor API.'
+      link: https://github.com/goharbor/go-client
+    - title: Mittwald Goharbor Client
+      description: Client API generated from OpenAPI specifications in golang.
+      link: https://github.com/mittwald/goharbor-client

--- a/data/ecosystem.yaml
+++ b/data/ecosystem.yaml
@@ -1,0 +1,12 @@
+- title: Harbor Helm Chart
+  description: The official Helm chart for deploying Harbor on Kubernetes clusters.
+  link: https://github.com/goharbor/harbor-helm
+- title: Terraform Provider for Harbor
+  description: A Terraform provider for managing Harbor resources like projects, users, and registries.
+  link: https://github.com/goharbor/terraform-provider-harbor
+- title: Harbor Next
+  description: The next generation of Harbor projects and architecture.
+  link: https://github.com/container-registry/harbor-next
+- title: Harbor Satellite
+  description: A lightweight Harbor extension for edge deployments and proxying.
+  link: https://github.com/container-registry/harbor-satellite

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -1,4 +1,4 @@
-{{- $inServerMode := .Site.IsServer }}
+{{- $inServerMode := hugo.IsServer }}
 {{- $includePaths := (slice "node_modules") }}
 {{- $sass         := "sass/style.sass" }}
 {{- $cssOutput    := "css/style.css" }}

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -1,4 +1,4 @@
-{{- $inServerMode := hugo.IsServer }}
+{{- $inServerMode := eq hugo.Environment "development" }}
 {{- $includePaths := (slice "node_modules") }}
 {{- $sass         := "sass/style.sass" }}
 {{- $cssOutput    := "css/style.css" }}

--- a/layouts/partials/ecosystem.html
+++ b/layouts/partials/ecosystem.html
@@ -1,17 +1,32 @@
-{{ $projects := site.Data.ecosystem }}
-<div class="container">
-  <div class="columns is-multiline">
-    {{ range $projects }}
-    <div class="column is-one-third">
-      <div class="card" style="height: 100%; display: flex; flex-direction: column;">
-        <div class="card-content" style="flex-grow: 1;">
-          <p class="title is-4"><a href="{{ .link }}" target="_blank" rel="noopener noreferrer">{{ .title }}</a></p>
-          <div class="content">
-            {{ .description }}
-          </div>
-        </div>
-      </div>
-    </div>
-    {{ end }}
-  </div>
+{{ $categories := site.Data.ecosystem }}
+<div class="container ecosystem-container">
+  {{ range $categories }}
+  <h2 class="title is-3" style="margin-top: 3rem; margin-bottom: 1rem;">{{ .category }}</h2>
+  <p class="subtitle is-5" style="margin-bottom: 1.5rem;">{{ .description }}</p>
+  
+  <table class="table is-fullwidth is-hoverable is-striped" style="margin-bottom: 3rem;">
+    <thead>
+      <tr>
+        <th style="width: 25%;">Project</th>
+        <th style="width: 50%;">Description</th>
+        <th style="width: 25%;">Source</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{ range .projects }}
+      <tr>
+        <td>
+          <strong><a href="{{ .link }}" target="_blank" rel="noopener noreferrer">{{ .title }}</a></strong>
+        </td>
+        <td>{{ .description }}</td>
+        <td>
+          <a href="{{ .link }}" target="_blank" rel="noopener noreferrer">
+            {{ replace .link "https://github.com/" "" }}
+          </a>
+        </td>
+      </tr>
+      {{ end }}
+    </tbody>
+  </table>
+  {{ end }}
 </div>

--- a/layouts/partials/ecosystem.html
+++ b/layouts/partials/ecosystem.html
@@ -1,0 +1,17 @@
+{{ $projects := site.Data.ecosystem }}
+<div class="container">
+  <div class="columns is-multiline">
+    {{ range $projects }}
+    <div class="column is-one-third">
+      <div class="card" style="height: 100%; display: flex; flex-direction: column;">
+        <div class="card-content" style="flex-grow: 1;">
+          <p class="title is-4"><a href="{{ .link }}" target="_blank" rel="noopener noreferrer">{{ .title }}</a></p>
+          <div class="content">
+            {{ .description }}
+          </div>
+        </div>
+      </div>
+    </div>
+    {{ end }}
+  </div>
+</div>

--- a/layouts/shortcodes/ecosystem.html
+++ b/layouts/shortcodes/ecosystem.html
@@ -1,0 +1,1 @@
+{{ partial "ecosystem.html" . }}


### PR DESCRIPTION
### Description

This PR introduces a new **Harbor Ecosystem** page (`/ecosystem`) to highlight community projects, extensions, and integrations built around Harbor, addressing the request in #748.

The basic skeleton is completely ready and fully matches the theme of the rest of the website. It utilizes a dynamic layout driven by a YAML data file to make it incredibly easy to maintain and scale.

### Screenshot

<img width="1440" height="779" alt="ecosystem page" src="https://github.com/user-attachments/assets/cddacf74-4528-4d7e-8ec5-0e65b8e69c52" />


**What's included:**

- **`content/ecosystem.md`**: The main page content
- **`data/ecosystem.yaml`**: The centralized data source for all ecosystem projects
- **`layouts/partials/ecosystem.html` & `layouts/shortcodes/ecosystem.html`**: The UI components responsible for generating the grid layout
- Updated `config.toml` to link the new page in the main navigation menu

### Missing Pieces / Next Steps

To get this started, I've populated the page with a few well-known projects (Harbor Helm Chart, Harbor Next, Harbor Satellite, Terraform Provider).

### How to add projects in the future

The page is built to be easily updated by the community. To add a new ecosystem project, contributors simply need to open a PR that appends their project to `data/ecosystem.yaml` in the following format:

```yaml
- title: Project Name
  description: A short description of the project.
  link: https://github.com/organization/project
```

### Related Issues

Fixes #748