### PR TITLE
docs: update Ubuntu version reference in Quick Install

### DIFF
--- a/docs/install-config/_index.md
+++ b/docs/install-config/_index.md
@@ -26,7 +26,7 @@ If installation fails, see [Troubleshooting Harbor Installation](troubleshoot-in
 
 ## Quick Installation
 
-You can run a script that deploys Harbor to Ubuntu 18.04 with a single command. For information, see [Deploy Harbor with the Quick Installation Script](quick-install-script.md).
+You can run a script that deploys Harbor to Ubuntu 24.04 with a single command. For information, see [Deploy Harbor with the Quick Installation Script](quick-install-script.md).
 
 ## Deploy Harbor on Kubernetes
 


### PR DESCRIPTION
This PR updates the Quick Install documentation to be version-agnostic, resolving the outdated Ubuntu 18.04 reference.

Resolves #751 (Originally reported in goharbor/harbor#23666)